### PR TITLE
Fix osenv KeyError & Parse desktop env properly

### DIFF
--- a/virtscreen/__main__.py
+++ b/virtscreen/__main__.py
@@ -79,7 +79,7 @@ def main() -> None:
 
 def check_env(msg: Callable[[str], None]) -> None:
     """Check enveironments before start"""
-    if os.environ['XDG_SESSION_TYPE'].lower() == 'wayland':
+    if os.environ.get('XDG_SESSION_TYPE', '').lower() == 'wayland':
         msg("Currently Wayland is not supported")
         sys.exit(1)
     if not HOME_PATH:

--- a/virtscreen/assets/data.json
+++ b/virtscreen/assets/data.json
@@ -34,7 +34,7 @@
             "value": "arandr",
             "name": "ARandR",
             "args": "arandr",
-            "XDG_CURRENT_DESKTOP": []
+            "XDG_CURRENT_DESKTOP": [""]
         }
     }
 }

--- a/virtscreen/qt_backend.py
+++ b/virtscreen/qt_backend.py
@@ -87,9 +87,8 @@ class Backend(QObject):
                 # Default Display settings app for a Desktop Environment
                 desktop_environ = os.environ.get('XDG_CURRENT_DESKTOP', '').lower()
                 for key, value in data['displaySettingApps'].items():
-                    for de in value['XDG_CURRENT_DESKTOP']:
-                        if de in desktop_environ:
-                            config["displaySettingApp"] = key
+                    if desktop_environ in value['XDG_CURRENT_DESKTOP']:
+                        config["displaySettingApp"] = key
             # Save the new config
             with open(CONFIG_PATH, 'w') as f:
                 f.write(json.dumps(config, indent=4, sort_keys=True))

--- a/virtscreen/qt_backend.py
+++ b/virtscreen/qt_backend.py
@@ -85,7 +85,7 @@ class Backend(QObject):
                     else:
                         value["available"] = False
                 # Default Display settings app for a Desktop Environment
-                desktop_environ = os.environ['XDG_CURRENT_DESKTOP'].lower()
+                desktop_environ = os.environ.get('XDG_CURRENT_DESKTOP', '').lower()
                 for key, value in data['displaySettingApps'].items():
                     for de in value['XDG_CURRENT_DESKTOP']:
                         if de in desktop_environ:


### PR DESCRIPTION
When using i3 and X11, several OS environment variables were not set, which caused a `KeyError` to be thrown by python.
While investigating these, I also noticed that the configuration file is not parsed correctly.

Now, I have used the `os.environ.get()` function to fetch the environment variables, and I have added an empty string to the configuration file for the `arandr` `displaySettingApp`, so that if the  `XDG_CURRENT_DESKTOP` environment variable is not set, then it will default to `arandr`.