### PR TITLE
Raise screen resolution cap to 8k

### DIFF
--- a/virtscreen/assets/DisplayPage.qml
+++ b/virtscreen/assets/DisplayPage.qml
@@ -17,7 +17,7 @@ ColumnLayout {
                 SpinBox {
                     value: settings.virt.width
                     from: 640
-                    to: 1920
+                    to: 8192
                     stepSize: 1
                     editable: true
                     onValueModified: {
@@ -31,7 +31,7 @@ ColumnLayout {
                 SpinBox {
                     value: settings.virt.height
                     from: 360
-                    to: 1080
+                    to: 4320
                     stepSize : 1
                     editable: true
                     onValueModified: {


### PR DESCRIPTION
I'm currently using VirtScreen with a 3440 x 1440 display, but the GUI caps out at 1920 x 1080. It would be great if these values could be raised.

In the commit, I chose the values of 8192x4320 representing 8K Full Format, because it seemed like a safely future proof resolution that is unlikely to break anything in the present.